### PR TITLE
Multilanguage templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var defaultOptions = {
 
   /* null or string
    * null is auto mode (detect by code)
-   * string is indent string, examples: '  ', '    ', '[TAB]' */
+   * string is indent string, examples: '  ', '    ', '\t' */
   indent: null,
 
   /* if "indent" option is null (auto mode) and can't detect indent by code
@@ -52,9 +52,9 @@ function buildFileTemplateData(file, options) {
         param: dep
       };
     }
-    amd.push('\'' + (dep.amd || dep.name) + '\'');
-    cjs.push('require(\'' + (dep.cjs || dep.name) + '\')');
-    global.push('root.' + (dep.global || dep.name));
+    amd.push(dep.amd || dep.name);
+    cjs.push(dep.cjs || dep.name);
+    global.push(dep.global || dep.name);
     param.push(dep.param || dep.name);
   });
 
@@ -63,10 +63,10 @@ function buildFileTemplateData(file, options) {
     exports: options.exports(file),
     namespace: options.namespace(file),
     // Adds resolved dependencies for each environment into the template data
-    amd: '[' + amd.join(', ') + ']',
-    cjs: cjs.join(', '),
-    global: global.join(', '),
-    param: param.join(', '),
+    amd: amd,
+    cjs: cjs,
+    global: global,
+    param: param,
     // =======================================================================
     indent: options.indent,
     defaultIndentValue: options.defaultIndentValue
@@ -87,12 +87,11 @@ function extend(target, source) {
 }
 
 function prepareIndent(options) {
-  var indentMatch;
-
   if (typeof options.contents !== 'string') {
     throw new Error('"contents" option must be a string.');
   }
 
+  var indentMatch;
   if (options.indent === null) {
     // auto detect by code
     indentMatch = options.contents.match(/^([ \t])/);
@@ -103,7 +102,6 @@ function prepareIndent(options) {
   }
 
   var getContentsWithIndent;
-
   (function (contents, indent) {
     getContentsWithIndent = function (count) {
       var indentStr = '';

--- a/index.js
+++ b/index.js
@@ -111,7 +111,8 @@ function prepareIndent(options) {
       return contents
         .replace(/\r\n/g, '\n')
         .replace(/\r/g, '\n')
-        .replace(/\n/g, '\n' + indentStr);
+        .replace(/\n/g, '\n' + indentStr)
+        .replace(/^[ \t]+$/gm, '');
     };
   })(options.contents.toString(), options.indent);
 

--- a/templates/returnExports.js
+++ b/templates/returnExports.js
@@ -1,12 +1,38 @@
-(function (root, factory) {
+<%
+  var amd_code = '';
+  if (amd.length > 0) {
+    amd_code = [];
+    amd.forEach(function (item) { amd_code.push("'" + item + "'"); });
+    amd_code = '[' + amd_code.join(', ') + '], ';
+  }
+
+  var cjs_code = '';
+  if (cjs.length > 0) {
+    cjs_code = [];
+    cjs.forEach(function (item) { cjs_code.push("require('" + item + "')"); });
+    cjs_code = cjs_code.join(', ');
+  }
+
+  var global_code = '';
+  if (global.length > 0) {
+    global_code = [];
+    global.forEach(function (item) { global_code.push('root.' + item); });
+    global_code = global_code.join(', ');
+  }
+
+  var param_code = '';
+  if (param.length > 0) {
+    param_code = param.join(', ');
+  }
+%>(function (root, factory) {
 <%= indent %>if (typeof define === 'function' && define.amd) {
-<%= indent %><%= indent %>define(<%= amd %>, factory);
+<%= indent %><%= indent %>define(<%= amd_code %>factory);
 <%= indent %>} else if (typeof exports === 'object') {
-<%= indent %><%= indent %>module.exports = factory(<%= cjs %>);
+<%= indent %><%= indent %>module.exports = factory(<%= cjs_code %>);
 <%= indent %>} else {
-<%= indent %><%= indent %>root.<%= namespace %> = factory(<%= global %>);
+<%= indent %><%= indent %>root.<%= namespace %> = factory(<%= global_code %>);
 <%= indent %>}
-}(this, function (<%= param %>) {
+}(this, function (<%= param_code %>) {
 <%= indent %><% var c = getContentsWithIndent(1); %><%= c %>
 <%= indent %>return <%= exports %>;
 }));

--- a/templates/returnExports.js
+++ b/templates/returnExports.js
@@ -1,12 +1,12 @@
-(function(root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define(<%= amd %>, factory);
-  } else if (typeof exports === 'object') {
-    module.exports = factory(<%= cjs %>);
-  } else {
-    root.<%= namespace %> = factory(<%= global %>);
-  }
-}(this, function(<%= param %>) {
-<%= contents %>
-return <%= exports %>;
+(function (root, factory) {
+<%= indent %>if (typeof define === 'function' && define.amd) {
+<%= indent %><%= indent %>define(<%= amd %>, factory);
+<%= indent %>} else if (typeof exports === 'object') {
+<%= indent %><%= indent %>module.exports = factory(<%= cjs %>);
+<%= indent %>} else {
+<%= indent %><%= indent %>root.<%= namespace %> = factory(<%= global %>);
+<%= indent %>}
+}(this, function (<%= param %>) {
+<%= indent %><% var c = getContentsWithIndent(1); %><%= c %>
+<%= indent %>return <%= exports %>;
 }));


### PR DESCRIPTION
It's about this issue: https://github.com/eduardolundgren/gulp-umd/issues/3

I replaced JavaScript-specific options to abstract data, and do what we need with this arrays in template.
Here my [template for LiveScript](https://github.com/unclechu/js-useful-umd-modules/blob/6f48a0bbcfe9fe9d0f0eb93146da570aa0202209/_dev/umd_template_1.3.ls) but no need to include this template to gulp-umd, cause this syntax is LiveScript version-specific. But with this pull request we can just write a template for new language (CoffeeScript ot TypeScript for example).