### PR TITLE
Fixed wrong syntax for gulp.dest() in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Then, in the gulp task:
 gulp.task('umd', function() {
   return gulp.src('src/*.js')
     .pipe(umd())
-    .dest('build');
+    .pipe(gulp.dest('build'));
 });
 ```
 
@@ -113,7 +113,7 @@ gulp.task('umd', function(file) {
           ];
         }
       }))
-    .dest('build');
+    .pipe(gulp.dest('build'));
 });
 ```
 
@@ -160,7 +160,7 @@ gulp.task('umd', function() {
           return 'Foo.Bar';
         }
     }))
-    .dest('build');
+    .pipe(gulp.dest('build'));
 });
 ```
 


### PR DESCRIPTION
Using the code given in the documentation throws the following error:

```
[14:11:37] TypeError: Object #<Stream> has no method 'dest'
    at Gulp.<anonymous> (.../gulpfile.js:11:6)
    at module.exports (.../node_modules/gulp/node_modules/orchestrator/lib/runTask.js:34:7)
    at Gulp.Orchestrator._runTask (.../node_modules/gulp/node_modules/orchestrator/index.js:273:3)
    at Gulp.Orchestrator._runStep (.../node_modules/gulp/node_modules/orchestrator/index.js:214:10)
    at Gulp.Orchestrator.start (.../node_modules/gulp/node_modules/orchestrator/index.js:134:8)
    at .../node_modules/gulp/bin/gulp.js:129:20
    at process._tickCallback (node.js:419:13)
    at Function.Module.runMain (module.js:499:11)
    at startup (node.js:119:16)
    at node.js:906:3
```

This is due to a mistake* in the docs: `.dest(build)` must be replaced by `.pipe(gulp.dest ('build'))`. Please refer to [Gulp API Documentation](https://github.com/gulpjs/gulp/blob/master/docs/API.md) for details.

This PR fixes the issue.

*: or could be due to a change in Gulp API