### PR TITLE
Adding semicolon before IIFE

### DIFF
--- a/templates/returnExports.js
+++ b/templates/returnExports.js
@@ -1,4 +1,4 @@
-(function(root, factory) {
+;(function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     define(<%= amd %>, factory);
   } else if (typeof exports === 'object') {


### PR DESCRIPTION
As IIFE when concatenated with other functions that do not use a semicolon in the end can cause functions to be executed, it would be good to add this semicolon, as it is no big change for you.