### PR TITLE
Added source map support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The following options are the ones available with the current default values:
 }
 ```
 
-* ```dependencies```
+* `dependencies`:
   Function which returns an array of dependencies.
   Each dependency is specified either as a string, or as an object of the form.
   ```js
@@ -74,7 +74,7 @@ The following options are the ones available with the current default values:
   }
   ```
   
-* ```exports```
+* `exports`:
   Specifies the item (or for CommonJS, *item's*) which the module will export.
   For non CommonJS, this value should be a string specifying the exported item.
   ```js
@@ -96,7 +96,7 @@ The following options are the ones available with the current default values:
   }
   ```
 
-* ```namespace```
+* `namespace`:
   Specifies the global namespace to export to. Only used for Web globals.
   ```js
   {
@@ -106,7 +106,7 @@ The following options are the ones available with the current default values:
   }
   ```
 
-* ```templateName```
+* `templateName`:
   Specifies the name of the template to use.
   Available template names are amd, amdNodeWeb, amdCommonWeb, amdWeb, common, node, returnExports and web. 
   *See above for descriptions.*
@@ -117,7 +117,7 @@ The following options are the ones available with the current default values:
   }
   ```
 
-* ```templateSource```
+* `templateSource`:
   Specifies the lodash template source to use when wrapping input files.
   If specified, overrides template.
   ```js
@@ -126,7 +126,7 @@ The following options are the ones available with the current default values:
   }
   ```
     
-* ```template```
+* `template`:
   Specifies the path to a file containing a lodash template to use when wrapping input files.
   ```
   {

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ This repository provides a simple way to build your files with support for the d
 
 The UMD pattern typically attempts to offer compatibility with the most popular script loaders of the day (e.g RequireJS amongst others). In many cases it uses [AMD](https://github.com/amdjs/amdjs-api/wiki/AMD) as a base, with special-casing added to handle [CommonJS](http://wiki.commonjs.org/wiki/CommonJS) compatibility.
 
-*Now with source map support!*
-
 ## Variations
 
 ### Regular Module

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This repository provides a simple way to build your files with support for the d
 
 The UMD pattern typically attempts to offer compatibility with the most popular script loaders of the day (e.g RequireJS amongst others). In many cases it uses [AMD](https://github.com/amdjs/amdjs-api/wiki/AMD) as a base, with special-casing added to handle [CommonJS](http://wiki.commonjs.org/wiki/CommonJS) compatibility.
 
+*Now with source map support!*
+
 ## Variations
 
 ### Regular Module

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function umd(options) {
     template = fs.readFileSync(template);
   }
   else if(options.templateSource) {
-    template = options.templateSource
+    template = options.templateSource;
   }
   else {
     template = fs.readFileSync(options.template);
@@ -121,7 +121,53 @@ function wrap(file, template, data, callback) {
 
   if (gutil.isBuffer(file.contents)) {
     data.contents = file.contents.toString();
+
+    if (file.sourceMap) {
+      (function () {
+        var sourceMap = require('source-map');
+        var applySourceMap = require('vinyl-sourcemaps-apply');
+        var generator = new sourceMap.SourceMapGenerator(file.sourceMap);
+        var consumer = new sourceMap.SourceMapConsumer(file.sourceMap);
+        var output;
+        var ilineAdustment = 0;
+        var correctContents = data.contents;
+        var correctContentsNewLines = correctContents.split('\n').length - 1;
+
+        // f8b4dd18-72da-4e25-80bb-451b67a88dba is just a magic number to find where the contents is being placed.
+        // It's a bit of a hack, but should cover 99% of use cases
+
+        data.contents = 'f8b4dd18-72da-4e25-80bb-451b67a88dba';
+        output = tpl(template, data);
+
+        output = output.split('\n').map(function (line, iline) {
+          return line.replace(/f8b4dd18-72da-4e25-80bb-451b67a88dba/g, function () {
+            consumer.eachMapping(function (mapping) {
+              return generator.addMapping({
+                generated: {
+                  line: mapping.generatedLine + iline + ilineAdustment,
+                  column: mapping.generatedColumn + (mapping.generatedLine == 1 ? (iline + ilineAdustment) : 0) // adjust first line
+                },
+                original: {
+                  line: mapping.originalLine,
+                  column: mapping.originalColumn
+                },
+                source: mapping.source,
+                name: mapping.name
+              });
+            });
+            ilineAdustment += correctContentsNewLines;
+            return correctContents;
+          });
+        }).join('\n');
+
+        file.contents = new Buffer(output);
+        applySourceMap(file, generator.toString());
+      })();
+    }
+    else {
     file.contents = new Buffer(tpl(template, data));
+    }
+
   }
   callback(null, file);
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,14 @@
     "gulp": "^3.8.8",
     "gulp-util": "^3.0.1",
     "lodash.template": "^2.4.1",
-    "nodeunit": "^0.9.0"
+    "nodeunit": "^0.9.0",
+    "source-map": "^0.4.4",
+    "vinyl-sourcemaps-apply": "^0.1.4"
+  },
+  "devDependencies": {
+    "gulp-coffee": "^2.3.1",
+    "gulp-if": "^1.2.5",
+    "gulp-rename": "^1.2.2",
+    "gulp-sourcemaps": "^1.5.2"
   }
 }

--- a/test/fixture/bar.coffee
+++ b/test/fixture/bar.coffee
@@ -1,0 +1,2 @@
+Bar = () ->
+  "some text"

--- a/test/fixture/sourceMaps/adjust.js
+++ b/test/fixture/sourceMaps/adjust.js
@@ -1,0 +1,22 @@
+;(function(root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define([], factory);
+  } else if (typeof exports === 'object') {
+    module.exports = factory();
+  } else {
+    root.Bar = factory();
+  }
+}(this, function() {
+(function() {
+  var Bar;
+
+  Bar = function() {
+    return "some text";
+  };
+
+}).call(this);
+
+return Bar;
+}));
+
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImJhci5jb2ZmZWUiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7Ozs7Ozs7O1NBQUE7QUFBQSxNQUFBOztFQUFBLEdBQUEsR0FBTSxTQUFBO1dBQ0o7RUFESTtBQUFOIiwiZmlsZSI6ImJhci5qcyIsInNvdXJjZVJvb3QiOiIvc291cmNlLyIsInNvdXJjZXNDb250ZW50IjpbIkJhciA9ICgpIC0+XHJcbiAgXCJzb21lIHRleHRcIlxyXG4iXX0=


### PR DESCRIPTION
The method I've used for adding source map support isn't as pure as I would like, but it will cover 90% of use cases.

Basically, I run the template using a magic number as the content. 
Then I replace every instance of the magic number with the actual content whilst also cloning and adjusting the incoming source map.

Take a look, see what you think. 