### PR TITLE
Gulp and nodeunit are dev dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
   ],
   "dependencies": {
     "event-stream": "^3.1.7",
-    "gulp": "^3.8.8",
     "gulp-util": "^3.0.1",
-    "lodash.template": "^2.4.1",
-    "nodeunit": "^0.9.0"
+    "lodash.template": "^2.4.1"
+  },
+  "devDependencies": {
+    "gulp": "^3.8.8",
+    "nodeunit": "^0.10.2"
   }
 }


### PR DESCRIPTION
These dependencies are not used in the exported module code.