### PR TITLE
Call wrap synchronously.

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,8 +39,8 @@ function umd(options) {
     template = fs.readFileSync(options.template);
   }
 
-  return es.map(function(file, callback) {
-    wrap(file, template, buildFileTemplateData(file, options), callback);
+  return es.mapSync(function(file) {
+    return wrap(file, template, buildFileTemplateData(file, options));
   });
 }
 
@@ -104,7 +104,7 @@ function extend(target, source) {
   return target;
 }
 
-function wrap(file, template, data, callback) {
+function wrap(file, template, data) {
   data.file = file;
 
   if (gutil.isStream(file.contents)) {
@@ -122,7 +122,8 @@ function wrap(file, template, data, callback) {
     data.contents = file.contents.toString();
     file.contents = new Buffer(tpl(template, data));
   }
-  callback(null, file);
+
+  return file;
 }
 
 module.exports = umd;


### PR DESCRIPTION
The callback passed to wrap was always called synchronously, so this is just a readability change.