### PR TITLE
Fix broken links on README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ The UMD pattern typically attempts to offer compatibility with the most popular 
 
 ### Regular Module
 
-* amdNodeWeb / returnExports / [templates/returnExports.js](https://github.com/umdjs/umd/blob/master/returnExports.js) -
+* amdNodeWeb / returnExports / [templates/returnExports.js](https://github.com/umdjs/umd/blob/master/templates/returnExports.js) -
   Defines a module that works in Node, AMD and browser globals. If you also want
   to export a global even when AMD is in play (useful if you are loading other
   scripts that still expect that global), use
-  [returnExportsGlobal.js](https://github.com/umdjs/umd/blob/master/returnExportsGlobal.js).
+  [returnExportsGlobal.js](https://github.com/umdjs/umd/blob/master/templates/returnExportsGlobal.js).
 
 * amd / [templates/amd.js](test/fixture/amd/testWithDependencies.js)
   Defines a module that works in AMD.


### PR DESCRIPTION
The [umdjs/umd](https://github.com/umdjs/umd) project moved their templates under a `/templates` directory breaking the links in the README.